### PR TITLE
Learning and Discussions in OpenJS Slack workspace

### DIFF
--- a/proposals/openjs-slack.md
+++ b/proposals/openjs-slack.md
@@ -1,0 +1,25 @@
+# Learning and Discussions in OpenJS Slack workspace
+
+Currently deck.gl and kepler.gl communities are a bit fragmented across Github, kepler.gl Slack, and deck.gl Slack. Now there's also a OpenJS slack, which is funded for this kind of use. 
+Messages are auto-deleted in the deck and kepler since Slack has substantially restricted their free-tier. For all the effort we spend answering questions, we'd ideally be able to keep these discussions around and help newcomers (as well as ourselves) be more efficiant.
+
+## Proposal
+
+I propose we gradually migrate the deck and kepler slack communities into channels on the OpenJS slack.
+
+Observing how other commuities do it, we'd start by clearly communitcating what we're doing and why. We'd pick a date, and ultimatly pull the bandade off with a hard-switch to avoid confusion.
+
+On day 1 we'd have:
+ - a new channel for deckgl-general and keplergl-general to join in OpenJS, and let other channels develop organically (rather than lay empty).
+ - an announcement to nudge folks to join in the old Slacks and pin a discussion on deckgl github
+ - Put an "auto-reply" on new messages in the old Slacks to build awareness of the move.
+ - Publish a new invite link on our (learning resources)[https://deck.gl/docs/get-started/learning-resources#community]
+
+One week before the move date:
+ - Another announcement in Slack and comment on the github discussion
+ 
+On moving day:
+ - Remove the old invite link in our (learning resources)[https://deck.gl/docs/get-started/learning-resources#community]
+ - Make an announcement on Slack
+ - Change the "auto-reply" to say we've moved
+

--- a/proposals/openjs-slack.md
+++ b/proposals/openjs-slack.md
@@ -1,7 +1,7 @@
 # Learning and Discussions in OpenJS Slack workspace
 
 Currently deck.gl and kepler.gl communities are a bit fragmented across Github, kepler.gl Slack, and deck.gl Slack. Now there's also a OpenJS slack, which is funded for this kind of use. 
-Messages are auto-deleted in the deck and kepler since Slack has substantially restricted their free-tier. For all the effort we spend answering questions, we'd ideally be able to keep these discussions around and help newcomers (as well as ourselves) be more efficiant.
+Messages are auto-deleted in the deck and kepler since Slack has substantially restricted their free-tier. For all the effort we spend answering questions, we'd ideally be able to keep these discussions around and help newcomers (as well as ourselves) be more efficiant. Slack is also used to announce releases.
 
 ## Proposal
 
@@ -10,10 +10,11 @@ I propose we gradually migrate the deck and kepler slack communities into channe
 Observing how other commuities do it, we'd start by clearly communitcating what we're doing and why. We'd pick a date, and ultimatly pull the bandade off with a hard-switch to avoid confusion.
 
 On day 1 we'd have:
- - a new channel for deckgl-general and keplergl-general to join in OpenJS, and let other channels develop organically (rather than lay empty).
- - an announcement to nudge folks to join in the old Slacks and pin a discussion on deckgl github
+ - a new channel for each framework: deckgl, keplergl, mathgl, loadersgl, lumagl, hubblegl, etc.
+ - a Slack announcement to nudge folks to join and pin a discussion on deckgl github
  - Put an "auto-reply" on new messages in the old Slacks to build awareness of the move.
  - Publish a new invite link on our (learning resources)[https://deck.gl/docs/get-started/learning-resources#community]
+ - Make the slack signup more prominent in our web pages, such as in the header.
 
 One week before the move date:
  - Another announcement in Slack and comment on the github discussion
@@ -22,4 +23,3 @@ On moving day:
  - Remove the old invite link in our (learning resources)[https://deck.gl/docs/get-started/learning-resources#community]
  - Make an announcement on Slack
  - Change the "auto-reply" to say we've moved
-


### PR DESCRIPTION
Proposal to gradually migrate the deck and kepler slack communities into channels on the OpenJS slack.