### PR TITLE
For OpenJS Review: `vis.gl` Charter and Governance Proposal for OpenJS

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,73 @@
+# vis.gl Charter
+
+Vis.gl aims to provide an open-source JavaScript framework for high-performance visualizations of large datasets on the web. It prioritizes strong support for geospatial data visualization, while also being flexible to cater to diverse non-geospatial visualization needs. It is designed to make advanced visualization techniques accessible to a wide range of developers by providing a user-friendly API and well-documented framework.
+
+## Section 0: Guiding Principles
+
+The `vis.gl` project is part of the [OpenJS Foundation](https://openjsf.org), which operates transparently, openly, collaboratively, and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to outsiders.
+
+
+## Section 1: Scope
+
+`vis.gl` is to provide a comprehensive, open-source solution for GPU-powered visualizations of large-scale datasets, in particular geospatial data visualizations. The `vis.gl` project consists of many different sub-projects, such as a layer-based visualization framework, GPU toolkit, basemap react components, and more. The project is designed to be modular, so that it can be used in a variety of different environments and for different purposes.
+
+
+### 1.1: In-scope
+
+ - Overseeing the **technical development** of the core vis.gl libraries and all affiliated sub-projects.
+ - **Release planning** and coordination
+ - Managing project repositories and **governance**, including issue tracking, pull request processes, and repository organization.
+ - Defining and enforcing **coding standards, testing practices, and development processes** to maintain code quality.
+ - Maintaining the list of **Maintainers and core contributors**, and setting permissions in project repositories.
+ - Reviewing and proposing **new project incubations or sub-projects**, as well as deciding on deprecations or significant changes to the project’s scope.
+ - Formation of technical **working groups**.
+ - **Representation** in technical collaborations with external communities.
+
+### 1.2: Out-of-Scope
+
+Section Intentionally Left Blank
+
+## Section 2: Relationship with OpenJS Foundation CPC.
+
+Technical leadership for the projects within the [OpenJS Foundation](https://openjsf.org/) is delegated to the projects through their project charters by the [OpenJS Foundation Cross-Project Council](https://openjsf.org/about/governance/) (CPC). In the case of the `vis.gl` project, it is delegated to the [Technical Steering Committee](https://github.com/visgl/tsc/blob/master/README.md#technical-steering-committee) (the “TSC”). The OpenJS Foundation's business leadership is the Board of Directors (the “Board”).
+
+This `vis.gl` Charter reflects a carefully constructed balanced role for the TSC and the CPC in the governance of the OpenJS Foundation. The charter amendment process is for the TSC to propose changes using simple majority of the full TSC, the proposed changes being subject to review and approval by the CPC. The CPC may additionally make amendments to the project charter at any time, though the CPC will not interfere with day-to-day discussions, votes, or meetings of the TSC.
+
+### 2.1 Other Formal Project Relationships
+
+Section Intentionally Left Blank
+
+## Section 3: `vis.gl`'s TSC Governing Body
+
+`vis.gl` is governed by its [Technical Steering Committee](https://github.com/visgl/tsc/blob/master/README.md#technical-steering-committee).
+
+## Section 4: Roles & Responsibilities 
+
+The roles and responsibilities of `vis.gl`'s TSC are described in [GOVERNANCE.md](./GOVERNANCE.md).
+
+### Section 4.1 Project Operations & Management
+
+Section Intentionally Left Blank
+
+### Section 4.2: Decision-making, Voting, and/or Elections
+
+The vis.gl TSC operates on a [consensus-seeking basis](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making). Most decisions are expected to be resolved through open discussion and agreement. However, when consensus cannot be reached, any TSC member may call for a vote.
+
+ - **Eligibility:** All steering committee members are voting members and may participate in any vote.
+
+ - **Quorum:** A quorum is established when at least 50% of steering committee members members are present. The steering committee members may meet without quorum, but may not make binding decisions.
+
+ - **Votes During Meetings:** When quorum is met, decisions require a simple majority of the steering committee members present.
+
+ - **Electronic Votes:** Decisions made asynchronously (e.g., over email or GitHub) require a simple majority of all steering committee members.
+
+ - **Escalation:** If a vote results in a tie or fails to resolve a dispute, any TSC member may refer the matter to the OpenJS Foundation Board for mediation or guidance.
+
+### Section 4.3: Other Project Roles
+
+Section Intentionally Left Blank
+
+## Section 5: Definitions
+
+- *Steering committee member*: A core maintainer of the project, provides leadership and oversees feature and technical directions.
+- *Maintainer*: Steering committee members delegate project responsibilities to maintainers, as documented in [GOVERNANCE.md](./GOVERNANCE.md).

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -4,24 +4,19 @@ Vis.gl aims to provide an open-source JavaScript framework for high-performance 
 
 ## Section 0: Guiding Principles
 
-The `vis.gl` project is part of the [OpenJS Foundation](https://openjsf.org), which operates transparently, openly, collaboratively, and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to outsiders.
+> We believe that powerful visualization should be accessible to every developer.
 
+We believe visualization tools should be declarative, composable, and interoperable—accessible to every developer and designed to work seamlessly within the broader ecosystem.
+
+Power shouldn’t come from complexity: layers, not low-level rendering; clear abstractions, not siloed systems. Our libraries should fit naturally alongside the tools developers already use, while staying modular and focused so each part can stand alone or be combined into a coherent whole.
 
 ## Section 1: Scope
 
 `vis.gl` is to provide a comprehensive, open-source solution for GPU-powered visualizations of large-scale datasets, in particular geospatial data visualizations. The `vis.gl` project consists of many different sub-projects, such as a layer-based visualization framework, GPU toolkit, basemap react components, and more. The project is designed to be modular, so that it can be used in a variety of different environments and for different purposes.
 
-
 ### 1.1: In-scope
 
- - Overseeing the **technical development** of the core vis.gl libraries and all affiliated sub-projects.
- - **Release planning** and coordination
- - Managing project repositories and **governance**, including issue tracking, pull request processes, and repository organization.
- - Defining and enforcing **coding standards, testing practices, and development processes** to maintain code quality.
- - Maintaining the list of **Maintainers and core contributors**, and setting permissions in project repositories.
- - Reviewing and proposing **new project incubations or sub-projects**, as well as deciding on deprecations or significant changes to the project’s scope.
- - Formation of technical **working groups**.
- - **Representation** in technical collaborations with external communities.
+Section Intentionally Left Blank  
 
 ### 1.2: Out-of-Scope
 
@@ -29,9 +24,9 @@ Section Intentionally Left Blank
 
 ## Section 2: Relationship with OpenJS Foundation CPC.
 
-Technical leadership for the projects within the [OpenJS Foundation](https://openjsf.org/) is delegated to the projects through their project charters by the [OpenJS Foundation Cross-Project Council](https://openjsf.org/about/governance/) (CPC). In the case of the `vis.gl` project, it is delegated to the [Technical Steering Committee](https://github.com/visgl/tsc/blob/master/README.md#technical-steering-committee) (the “TSC”). The OpenJS Foundation's business leadership is the Board of Directors (the “Board”).
+The OpenJS Cross Project Council (CPC) delegates technical leadership of this project to the governing body defined in Section 3 of this charter.
 
-This `vis.gl` Charter reflects a carefully constructed balanced role for the TSC and the CPC in the governance of the OpenJS Foundation. The charter amendment process is for the TSC to propose changes using simple majority of the full TSC, the proposed changes being subject to review and approval by the CPC. The CPC may additionally make amendments to the project charter at any time, though the CPC will not interfere with day-to-day discussions, votes, or meetings of the TSC.
+This project is entitled to representation in the CPC through voting members as described in [Section 4](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#voting-members) of the CPC Charter.
 
 ### 2.1 Other Formal Project Relationships
 
@@ -43,7 +38,7 @@ Section Intentionally Left Blank
 
 ## Section 4: Roles & Responsibilities 
 
-The roles and responsibilities of `vis.gl`'s TSC are described in [GOVERNANCE.md](./GOVERNANCE.md).
+The responsibilities of `vis.gl`'s TSC are described in [Section 6](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-6-non-responsibilities-of-the-cpc) of the CPC Charter.
 
 ### Section 4.1 Project Operations & Management
 
@@ -51,7 +46,7 @@ Section Intentionally Left Blank
 
 ### Section 4.2: Decision-making, Voting, and/or Elections
 
-The vis.gl TSC operates on a [consensus-seeking basis](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making). Most decisions are expected to be resolved through open discussion and agreement. However, when consensus cannot be reached, any TSC member may call for a vote.
+Decision making and voting follow the practices adopted by the CPC and described in [Section 9](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-9-decision-making) and [Section 10](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-10-voting) of the CPC Charter respectively.
 
  - **Eligibility:** All steering committee members are voting members and may participate in any vote.
 
@@ -69,5 +64,8 @@ Section Intentionally Left Blank
 
 ## Section 5: Definitions
 
-- *Steering committee member*: A core maintainer of the project, provides leadership and oversees feature and technical directions.
-- *Maintainer*: Steering committee members delegate project responsibilities to maintainers, as documented in [GOVERNANCE.md](./GOVERNANCE.md).
+Section Intentionally Left Blank
+
+## Section 6: Changes to this Document
+
+Changes to this document require [approval from the CPC](https://github.com/openjs-foundation/cross-project-council/blob/main/governance/GOVERNANCE.md#approving-project-charters).

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,6 +1,6 @@
 # vis.gl Charter
 
-Vis.gl aims to provide an open-source JavaScript framework for high-performance visualizations of large datasets on the web. It prioritizes strong support for geospatial data visualization, while also being flexible to cater to diverse non-geospatial visualization needs. It is designed to make advanced visualization techniques accessible to a wide range of developers by providing a user-friendly API and well-documented framework.
+Vis.gl aims to provide an open-source JavaScript framework for high-performance visualizations of large datasets on the web. It prioritizes strong support for geospatial data visualization, while also being flexible enough to cater to diverse non-geospatial visualization needs. It is designed to make advanced visualization techniques accessible to a wide range of developers by providing a user-friendly API and well-documented framework.
 
 ## Section 0: Guiding Principles
 
@@ -12,7 +12,7 @@ Power shouldn’t come from complexity: layers, not low-level rendering; clear a
 
 ## Section 1: Scope
 
-`vis.gl` is to provide a comprehensive, open-source solution for GPU-powered visualizations of large-scale datasets, in particular geospatial data visualizations. The `vis.gl` project consists of many different sub-projects, such as a layer-based visualization framework, GPU toolkit, basemap react components, and more. The project is designed to be modular, so that it can be used in a variety of different environments and for different purposes.
+`vis.gl` provides a comprehensive, open-source solution for GPU-powered visualizations of large-scale datasets, in particular geospatial data visualizations. The `vis.gl` project consists of many different sub-projects, such as a layer-based visualization framework, GPU toolkit, basemap react components, and more. The project is designed to be modular, so that it can be used in a variety of different environments and for different purposes.
 
 ### 1.1: In-scope
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -48,16 +48,6 @@ Section Intentionally Left Blank
 
 Decision making and voting follow the practices adopted by the CPC and described in [Section 9](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-9-decision-making) and [Section 10](https://github.com/openjs-foundation/cross-project-council/blob/main/CPC-CHARTER.md#section-10-voting) of the CPC Charter respectively.
 
- - **Eligibility:** All steering committee members are voting members and may participate in any vote.
-
- - **Quorum:** A quorum is established when at least 50% of steering committee members members are present. The steering committee members may meet without quorum, but may not make binding decisions.
-
- - **Votes During Meetings:** When quorum is met, decisions require a simple majority of the steering committee members present.
-
- - **Electronic Votes:** Decisions made asynchronously (e.g., over email or GitHub) require a simple majority of all steering committee members.
-
- - **Escalation:** If a vote results in a tie or fails to resolve a dispute, any TSC member may refer the matter to the OpenJS Foundation Board for mediation or guidance.
-
 ### Section 4.3: Other Project Roles
 
 Section Intentionally Left Blank

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,7 @@ There are three types of roles in the community that maintains this project:
 
 The list of current steering committee members are documented in the visgl org's [TSC repo](../README.md). Maintainers are documented in each repo's contributing guide (e.g. [`/CONTRIBUTING.md`](https://github.com/visgl/deck.gl/blob/master/CONTRIBUTING.md)).
 
+The [TSC Charter](./CHARTER.md) governs the operations of the TSC. All changes to the Charter need approval by the OpenJS Foundation Cross-Project Council (CPC).
 
 ## The Steering Committee
 
@@ -34,7 +35,7 @@ All of a maintainer's privileges (2a), and the following:
 - Organize and moderate community discussions, enforce the code of conduct;
 - Ensure that the dev process is followed by all contributors;
 - Ensure the consistency and quality of the documentation;
-- Manage blog posts, material for conference and meetup talks, and other brand presence.
+- Manage blog posts, material for conference and meetup talks, and other brand presence in accordance with the OpenJS Project Marketing Guidelines.
 
 ### 1c. Becoming a steering committee member
 
@@ -63,7 +64,7 @@ If a steering committee member can/will no longer perform their duties, they can
   + Push to a branch in the main repo.
   + Be added as a code reviewer by other contributors.
 - Represent vis.gl publicly
-  + Publish articles in the [vis-gl blog](https://medium.com/vis-gl).
+  + Publish articles in the [vis-gl blog](https://medium.com/vis-gl) in accordance with the OpenJS Project Marketing Guidelines.
   + Promote vis.gl at conferences and meetups.
 
 


### PR DESCRIPTION
Reopens the vis.gl project charter for review with the OpenJS CPC. See #13 for maintainer discussion and more context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new vis.gl Charter and updates governance to reference it and align communications with OpenJS CPC marketing guidelines.
> 
> - **Documentation**:
>   - **New Charter** (`CHARTER.md`): Introduces guiding principles, scope, CPC relationship, TSC governance, decision-making, and change-approval process.
>   - **Governance updates** (`GOVERNANCE.md`):
>     - Reference the new TSC Charter and CPC approval requirement.
>     - Clarify responsibilities and public communications to follow OpenJS Project Marketing Guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84517c84efc61db2e331421afa7a14551ddbc17a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->